### PR TITLE
Update force.py

### DIFF
--- a/mtuq/grid/force.py
+++ b/mtuq/grid/force.py
@@ -11,12 +11,24 @@ from mtuq.util.math import open_interval as regular
 from mtuq.util.lune import to_force
 
 
-
 def ForceGridRegular(magnitudes_in_N=1., npts_per_axis=80):
     """ Force grid with regularly-spaced values
+
+    Given input parameters ``magnitudes_in_N`` (`list`) and
+    ``npts_per_axis`` (`int`), returns a ``Grid`` of size
+    `len(magnitudes_in_N)*npts_per_axis^2`.
+
+    .. rubric :: Usage
+
+    Use ``get(i)`` to return the i-th force as a vector
+    `Frr, Ftt, Fpp`
+
+    Use ``get_dict(i)`` to return the i-th force as dictionary
+    of parameters `F0, theta, h` (magnitude, azimuth, cos(colatitude)).
+
     """
-    theta = regular(0., 360., npts)
-    h = regular(-1., 1., npts)
+    theta = regular(0., 360., npts_per_axis)
+    h = regular(-1., 1., npts_per_axis)
     F0 = asarray(magnitudes_in_N)
 
     return Grid(
@@ -27,6 +39,19 @@ def ForceGridRegular(magnitudes_in_N=1., npts_per_axis=80):
 
 def ForceGridRandom(magnitudes_in_N=1., npts=10000):
     """ Force grid with randomly-spaced values
+
+    Given input parameters ``magnitudes_in_N`` (`list`) and
+    ``npts`` (`int`), returns an ``UnstructuredGrid`` of size
+    `npts*len(magnitudes_in_N)`.
+
+    .. rubric :: Usage
+
+    Use ``get(i)`` to return the i-th force as a vector
+    `Frr, Ftt, Fpp`
+
+    Use ``get_dict(i)`` to return the i-th force as dictionary
+    of parameters `F0, theta, h` (magnitude, azimuth, cos(colatitude)).
+
     """
     theta = random(0., 360., npts)
     h = random(-1., 1., npts)


### PR DESCRIPTION
Fixed inconsistent variable name in ForceGridRegular
Added descriptions of ForceGridRegular and ForceGridRandom following nomenclature in moment_tensor.py

Please check that the ordering of the get function (Frr, Ftt, Fpp) is correct?