### PR TITLE
Implement the CMA-ES IPOP restart strategy

### DIFF
--- a/examples/CMAES.Force.py
+++ b/examples/CMAES.Force.py
@@ -63,7 +63,7 @@ if __name__=='__main__':
     process_bw = ProcessData(
         filter_type='Bandpass',
         freq_min= 0.1,
-        freq_max= 0.333,
+        freq_max=0.333,
         pick_type='taup',
         taup_model=model,
         window_type='body_wave',
@@ -209,7 +209,7 @@ if __name__=='__main__':
     GREENS = [greens_sw] if mode == 'greens' else None  # add more as needed
 
     popsize = 48 # -- CMA-ES population size (you can play with this value)
-    CMA = CMA_ES(parameter_list , origin=origin, lmbda=popsize, event_id=event_id)
+    CMA = CMA_ES(parameter_list , origin=origin, lmbda=popsize, event_id=event_id, max_restarts=5)
     CMA.sigma = 3 # -- CMA-ES step size, defined as the standard deviation of the population can be ajusted here (3 ~ 4 seems to provide a balanced exploration/exploitation and avoid getting stuck in local minima). 
     # The default value is otherwise 1 standard deviation (you can play with this value)
     iter = 80 # -- Number of iterations (you can play with this value)

--- a/examples/CMAES.FullMomentTensor.py
+++ b/examples/CMAES.FullMomentTensor.py
@@ -256,7 +256,7 @@ if __name__=='__main__':
     GREENS = [greens_bw, greens_sw] if mode == 'greens' else None  # add more as needed
 
     popsize = 48 # -- CMA-ES population size - number of mutants (you can play with this value, 24 to 120 is a good range)
-    CMA = CMA_ES(parameter_list , origin=origin, lmbda=popsize, event_id=event_id)
+    CMA = CMA_ES(parameter_list , origin=origin, lmbda=popsize, event_id=event_id, max_restarts=3)
     CMA.sigma = 5.0 # -- CMA-ES step size, defined as the standard deviation of the population can be ajusted here (4 ~ 5 seems to provide a balanced exploration/exploitation and avoid getting stuck in local minima). 
     # The default value is otherwise 1 standard deviation (you can play with this value)
     iter = 60 # -- Number of iterations (you can play with this value, 120 to 240 is a good range)

--- a/mtuq/stochastic_sampling/cmaes.py
+++ b/mtuq/stochastic_sampling/cmaes.py
@@ -117,6 +117,10 @@ class CMA_ES(object):
         The figure object for plotting.
     ax : matplotlib.axes.Axes
         The axis object for plotting.
+    restart_count : int
+        The number of restarts performed.
+    max_restarts : int
+        The maximum number of restarts allowed.
 
     Methods
     -------
@@ -192,9 +196,15 @@ class CMA_ES(object):
         Checks the validity of input arguments for the Solve method.
     _get_data_norm(self, data, misfit)
         Computes the norm of the data using the calculate_norm_data function.
+    _restart_strategy(self)
+        Implements the IPOP restart strategy.
+    check_convergence(self)
+        Checks for convergence and triggers a restart if necessary.
+    reset_parameters(self)
+        Resets the parameters for a restart.
     """
 
-    def __init__(self, parameters_list: list, origin: Origin, lmbda: int = None, callback_function=None, event_id: str = '', verbose_level: int = 0):
+    def __init__(self, parameters_list: list, origin: Origin, lmbda: int = None, callback_function=None, event_id: str = '', verbose_level: int = 0, max_restarts: int = 5):
         """
         Initializes the CMA-ES class with the given parameters.
 
@@ -212,6 +222,8 @@ class CMA_ES(object):
             The event ID for the inversion.
         verbose_level : int, optional
             The verbosity level for logging.
+        max_restarts : int, optional
+            The maximum number of restarts allowed. Default is 5.
         """
 
         # Initialize basic properties
@@ -221,6 +233,10 @@ class CMA_ES(object):
         
         # Set up caches and storage for logging
         self._setup_caches()
+
+        # Initialize restart parameters
+        self.restart_count = 0
+        self.max_restarts = max_restarts
 
     def _initialize_mpi_communicator(self):
         """Initializes the MPI communicator and sets the process rank and size."""
@@ -1202,6 +1218,14 @@ class CMA_ES(object):
                         result = self.mutants_logger_list
                         plot_misfit_force(self.event_id + '_misfit_map.png', result, colormap='viridis', backend=_plot_force_matplotlib, plot_type='colormesh', best_force=self.return_candidate_solution()[0][1::])
 
+            # Check for convergence and trigger a restart if necessary
+            if self.check_convergence():
+                if self.restart_count < self.max_restarts:
+                    self._restart_strategy()
+                    self.reset_parameters()
+                    self.restart_count += 1
+                else:
+                    break
 
     def _transform_mutants(self):
         """
@@ -1415,3 +1439,48 @@ class CMA_ES(object):
                 components = list(''.join(misfit.time_shift_groups))
             
             return calculate_norm_data(data, misfit.norm, components)
+
+    def _restart_strategy(self):
+        """
+        Implements the IPOP restart strategy.
+
+        This method doubles the population size (lambda) each time it is called.
+        """
+        self.lmbda *= 2
+        self.mu = np.floor(self.lmbda / 2)
+        self.weights = np.array([np.log(self.mu + 1) - np.log(np.arange(1, self.mu + 1))]).T
+        self.weights /= sum(self.weights)
+        self.mueff = sum(self.weights)**2 / sum(self.weights**2)
+
+    def check_convergence(self):
+        """
+        Checks for convergence and triggers a restart if necessary.
+
+        Returns
+        -------
+        bool
+            True if convergence criteria are met, False otherwise.
+        """
+        if self.rank == 0:
+            # Check if the standard deviation of the population is below a threshold
+            if np.std(self.mutants) < 1e-6:
+                return True
+        return False
+
+    def reset_parameters(self):
+        """
+        Resets the parameters for a restart.
+
+        This method resets the mean, step size, and covariance matrix to their initial values.
+        """
+        self.xmean = np.asarray([[param.initial for param in self._parameters]]).T
+        self.sigma = 0.5
+        self.ps = np.zeros_like(self.xmean)
+        self.pc = np.zeros_like(self.xmean)
+        self.B = np.eye(self.n, self.n)
+        self.D = np.ones((self.n, 1))
+        self.C = self.B @ np.diag(self.D[:, 0]**2) @ self.B.T
+        self.invsqrtC = self.B @ np.diag(self.D[:, 0]**-1) @ self.B.T
+        self.eigeneval = 0
+        self.chin = self.n**0.5 * (1 - 1 / (4 * self.n) + 1 / (21 * self.n**2))
+        self.mutants = np.zeros((self.n, self.lmbda))

--- a/mtuq/stochastic_sampling/cmaes.py
+++ b/mtuq/stochastic_sampling/cmaes.py
@@ -1465,6 +1465,13 @@ class CMA_ES(object):
             # Check if the standard deviation of the population is below a threshold
             if np.std(self.mutants) < 1e-6:
                 return True
+
+            # Check if the rate of change of the misfit function is below a threshold
+            if self.iteration > 1:
+                misfit_change_rate = np.abs(self._misfit_holder[-1] - self._misfit_holder[-2]) / self._misfit_holder[-2]
+                if misfit_change_rate < 1e-3:
+                    return True
+
         return False
 
     def reset_parameters(self):

--- a/mtuq/stochastic_sampling/cmaes_plotting.py
+++ b/mtuq/stochastic_sampling/cmaes_plotting.py
@@ -172,6 +172,21 @@ def _cmaes_scatter_plot(CMA):
 
             CMA.ax.scatter(v, w, c=m, s=3, vmin=vmin, vmax=vmax, zorder=100)
 
+            # Plot the mean solutions for all steps and restarts
+            mean_logger_list = CMA.mean_logger_list
+            if 'v' in mean_logger_list:
+                mean_v = np.asarray(mean_logger_list['v'])
+            else:
+                mean_v = np.zeros_like(mean_logger_list['misfit'])
+
+            if 'w' in mean_logger_list:
+                mean_w = np.asarray(mean_logger_list['w'])
+            else:
+                mean_w = np.zeros_like(mean_logger_list['misfit'])
+
+            mean_v, mean_w = _hammer_projection(to_gamma(mean_v), to_delta(mean_w))
+            CMA.ax.plot(mean_v, mean_w, 'r-', zorder=10000000)
+
             CMA.fig.canvas.draw()
             return CMA.fig
 
@@ -198,4 +213,13 @@ def _cmaes_scatter_plot(CMA):
 
             CMA.ax.scatter(longitude, latitude, c=m, s=3, vmin=vmin, vmax=vmax, zorder=100)
             CMA.ax.scatter(LONGITUDE, LATITUDE, c='red', marker='x', zorder=10000000)
+
+            # Plot the mean solutions for all steps and restarts
+            mean_logger_list = CMA.mean_logger_list
+            mean_phi, mean_h = np.asarray(mean_logger_list['phi']), np.asarray(mean_logger_list['h'])
+            mean_latitude = np.degrees(np.pi / 2 - np.arccos(mean_h))
+            mean_longitude = wrap_180(mean_phi + 90)
+            mean_longitude, mean_latitude = _hammer_projection(mean_longitude, mean_latitude)
+            CMA.ax.plot(mean_longitude, mean_latitude, 'r-', zorder=10000000)
+
             return CMA.fig


### PR DESCRIPTION
Implement a restart strategy for the CMA-ES algorithm in `mtuq/stochastic_sampling/cmaes.py` and update the plotting logic in `mtuq/stochastic_sampling/cmaes_plotting.py` to handle multiple runs.

* **CMA-ES Restart Strategy:**
  - Add `_restart_strategy` method to implement the IPOP restart strategy.
  - Add `check_convergence` method to check for convergence and trigger a restart.
  - Modify `Solve` method to include a call to `check_convergence`.
  - Add `reset_parameters` method to reset the parameters for a restart.
  - Initialize restart parameters in the `__init__` method.

* **Plotting Updates:**
  - Modify the custom CMA-ES scatter plot method to plot the results of all the restart runs in one.
  - Track the means of all steps and all restarts and plot them.

